### PR TITLE
update existing tests to use `ExpectedException` instead of `@Test(expected = SomeException.class)`

### DIFF
--- a/src/test/java/pl/touk/throwing/CheckerTest.java
+++ b/src/test/java/pl/touk/throwing/CheckerTest.java
@@ -1,6 +1,9 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
 
 import java.io.IOException;
@@ -11,36 +14,53 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.not;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.fail;
 import static pl.touk.throwing.ThrowingFunction.unchecked;
 
 public class CheckerTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-    @Test(expected = URISyntaxException.class)
+    @Test
     public void shouldUnwrapOriginalExceptionWithTryCatch() throws Throwable {
+        thrown.expect(URISyntaxException.class);
+        thrown.expectMessage("Illegal character in path at index 1: . .");
 
         // when
         Checker.checked(() -> Stream.of(". .").map(unchecked(URI::new)).collect(toList()));
 
         // then a checked exception is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = URISyntaxException.class)
+    @Test
     public void shouldUnwrapSpecifiedExceptionWithTryCatch() throws Throwable {
+        thrown.expect(URISyntaxException.class);
+        thrown.expectMessage("Illegal character in path at index 1: . .");
 
         // when
         Checker.checked(URISyntaxException.class,
                 () -> Stream.of(". .").map(unchecked(URI::new)).collect(toList()));
 
         // then a checked exception is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldIgnoreUnspecifiedExceptionWithTryCatch() throws Throwable {
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("Illegal character in path at index 1: . .");
+        thrown.expectCause(not(isA(IOException.class)));
 
         // when
         Checker.checked(IOException.class, () -> Stream.of(". .").map(unchecked(URI::new)).collect(toList()));
 
         // then a checked exception is thrown
+        fail("exception expected");
     }
 
     @Test
@@ -69,8 +89,10 @@ public class CheckerTest {
         assertThat(result).isEqualTo("A");
     }
 
-    @Test(expected = URISyntaxException.class)
+    @Test
     public void shouldUnwrapOriginalExceptionWhenUsingStandardUtilsFunctions() throws URISyntaxException {
+        thrown.expect(URISyntaxException.class);
+        thrown.expectMessage("Illegal character in path at index 1: . .");
 
         // when
         Checker.checked(URISyntaxException.class,
@@ -80,5 +102,6 @@ public class CheckerTest {
         );
 
         // then a checked exception is thrown
+        fail("exception expected");
     }
 }

--- a/src/test/java/pl/touk/throwing/TestCommons.java
+++ b/src/test/java/pl/touk/throwing/TestCommons.java
@@ -10,4 +10,10 @@ public final class TestCommons {
             throw new Exception();
         };
     }
+
+    static ThrowingFunction<Integer, Integer, Exception> givenThrowingFunction(String message) throws Exception {
+        return i -> {
+            throw new Exception(message);
+        };
+    }
 }

--- a/src/test/java/pl/touk/throwing/ThrowingBiConsumerTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingBiConsumerTest.java
@@ -1,12 +1,20 @@
 package pl.touk.throwing;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
 public class ThrowingBiConsumerTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldConsume() throws Exception {
@@ -51,15 +59,22 @@ public class ThrowingBiConsumerTest {
         Assertions.assertThat(input[0]).isEqualTo(2);
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldConsumeAndThrowUnchecked() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        ThrowingBiConsumer<Integer, Integer, IOException> consumer = (i, j) -> { throw new IOException(); };
+        ThrowingBiConsumer<Integer, Integer, IOException> consumer = (i, j) -> { throw cause; };
 
         // when
         ThrowingBiConsumer.unchecked(consumer).accept(3, 3);
 
         // then WrappedException was thrown
+        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/pl/touk/throwing/ThrowingBiFunctionTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingBiFunctionTest.java
@@ -1,13 +1,21 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 
 public class ThrowingBiFunctionTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldAndThen() throws Exception {
@@ -46,37 +54,55 @@ public class ThrowingBiFunctionTest {
         assertThat(result).isEmpty();
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldThrowEx() throws Exception {
+        thrown.expect(Exception.class);
+        thrown.expectMessage("some message");
+
         // given
-        final ThrowingBiFunction<Integer, Integer, Integer, Exception> f1 = (i, j) -> { throw new Exception(); };
+        final ThrowingBiFunction<Integer, Integer, Integer, Exception> f1 = (i, j) -> { throw new Exception("some message"); };
 
         // when
         f1.apply(42, 42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldWrapInWrappedEx() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        final ThrowingBiFunction<Integer, Integer, Integer, Exception> f1 = (i, j) -> { throw new Exception(); };
+        final ThrowingBiFunction<Integer, Integer, Integer, Exception> f1 = (i, j) -> { throw cause; };
 
         // when
         f1.unchecked().apply(42, 42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldWrapInRuntimeExWhenUsingUnchecked() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        final ThrowingBiFunction<Integer, Integer, Integer, Exception> f1 = (i, j) -> { throw new Exception(); };
+        final ThrowingBiFunction<Integer, Integer, Integer, Exception> f1 = (i, j) -> { throw cause; };
 
         // when
         ThrowingBiFunction.unchecked(f1).apply(42, 42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/pl/touk/throwing/ThrowingBiPredicateTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingBiPredicateTest.java
@@ -1,10 +1,18 @@
 package pl.touk.throwing;
 
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 public class ThrowingBiPredicateTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldTest() throws Exception {
@@ -78,17 +86,24 @@ public class ThrowingBiPredicateTest {
         assertThat(p.asFunction().apply(1, 2)).isTrue();
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldWrapInRuntimeExWhenUsingStandardUtilsFunctions() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
         final ThrowingBiPredicate<Integer, Integer, Exception> predicate = (i, j) -> {
-            throw new Exception();
+            throw cause;
         };
 
         // when
         ThrowingBiPredicate.unchecked(predicate).test(42, 0);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/pl/touk/throwing/ThrowingBinaryOperatorTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingBinaryOperatorTest.java
@@ -2,10 +2,20 @@ package pl.touk.throwing;
 
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
 
 public class ThrowingBinaryOperatorTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void shouldAndThen() throws Exception {
         // given
@@ -44,40 +54,58 @@ public class ThrowingBinaryOperatorTest {
         assertThat(result).isEmpty();
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldThrowEx() throws Exception {
+        thrown.expect(Exception.class);
+        thrown.expectMessage("some message");
+
         // given
         final ThrowingBinaryOperator<Integer, Exception> f1 = 
-            (i, j) -> { throw new Exception(); };
+            (i, j) -> { throw new Exception("some message"); };
 
         // when
         f1.apply(42, 42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldWrapInWrappedEx() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
         final ThrowingBinaryOperator<Integer, Exception> f1 = 
-            (i, j) -> { throw new Exception(); };
+            (i, j) -> { throw cause; };
 
         // when
         f1.unchecked().apply(42, 42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldWrapInRuntimeExWhenUsingUnchecked() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
         final ThrowingBinaryOperator<Integer, Exception> f1 = 
-            (i, j) -> { throw new Exception(); };
+            (i, j) -> { throw cause; };
 
         // when
-        ThrowingBiFunction.unchecked(f1).apply(42, 42);
+        ThrowingBinaryOperator.unchecked(f1).apply(42, 42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
     @Test
@@ -86,7 +114,7 @@ public class ThrowingBinaryOperatorTest {
         final ThrowingBinaryOperator<Integer, Exception> f1 = (i, j) -> i + j;
 
         // when
-        ThrowingBiFunction.unchecked(f1).apply(42, 0);
+        ThrowingBinaryOperator.unchecked(f1).apply(42, 0);
 
         // then no exception thrown
     }

--- a/src/test/java/pl/touk/throwing/ThrowingConsumerTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingConsumerTest.java
@@ -1,12 +1,21 @@
 package pl.touk.throwing;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
 public class ThrowingConsumerTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldConsume() throws Exception {
@@ -51,15 +60,22 @@ public class ThrowingConsumerTest {
         Assertions.assertThat(input[0]).isEqualTo(2);
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldConsumeAndThrowUnchecked() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        ThrowingConsumer<Integer, IOException> consumer = i -> { throw new IOException(); };
+        ThrowingConsumer<Integer, IOException> consumer = i -> { throw cause; };
 
         // when
         ThrowingConsumer.unchecked(consumer).accept(3);
 
         // then WrappedException was thrown
+        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/pl/touk/throwing/ThrowingFunctionTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingFunctionTest.java
@@ -1,18 +1,26 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.fail;
 import static pl.touk.throwing.TestCommons.givenThrowingFunction;
 import static pl.touk.throwing.ThrowingFunction.lifted;
 import static pl.touk.throwing.ThrowingFunction.unchecked;
 
 public class ThrowingFunctionTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldCompose() throws Exception {
@@ -65,35 +73,47 @@ public class ThrowingFunctionTest {
         assertThat(result.isPresent()).isFalse();
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldThrowEx() throws Exception {
+        thrown.expect(Exception.class);
+        thrown.expectMessage("custom exception message");
+        
         // given
-        final ThrowingFunction<Integer, Integer, Exception> f1 = givenThrowingFunction();
+        final ThrowingFunction<Integer, Integer, Exception> f1 = givenThrowingFunction("custom exception message");
 
         // when
         f1.apply(42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldWrapInRuntimeEx() throws Exception {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("custom exception message");
+        
         // given
-        final ThrowingFunction<Integer, Integer, Exception> f1 = givenThrowingFunction();
+        final ThrowingFunction<Integer, Integer, Exception> f1 = givenThrowingFunction("custom exception message");
 
         // when
         f1.uncheck().apply(42);
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldWrapInRuntimeExWhenUsingUnchecked() throws Exception {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Illegal character in path at index 1: . .");
+        thrown.expectCause(isA(URISyntaxException.class));
 
         // when
         Stream.of(". .").map(unchecked(URI::new)).collect(toList());
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/pl/touk/throwing/ThrowingPredicateTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingPredicateTest.java
@@ -1,14 +1,21 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 import static pl.touk.throwing.ThrowingPredicate.unchecked;
 
 public class ThrowingPredicateTest {
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldTest() throws Exception {
@@ -83,11 +90,17 @@ public class ThrowingPredicateTest {
                 .isInstanceOf(ThrowingFunction.class);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldWrapInRuntimeExWhenUsingStandardUtilsFunctions() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
         final ThrowingPredicate<Integer, Exception> predicate = i -> {
-            throw new Exception();
+            throw cause;
         };
         final List<Integer> integers = Collections.singletonList(42);
 
@@ -95,6 +108,7 @@ public class ThrowingPredicateTest {
         integers.stream().anyMatch(i -> unchecked(predicate).test(i));
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
 
     @Test
@@ -109,11 +123,17 @@ public class ThrowingPredicateTest {
         // then RuntimeException is thrown
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldWrapInRuntimeExWhenUsingUncheck() throws Exception {
+        final Exception cause = new Exception("some message");
+        
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
         final ThrowingPredicate<Integer, Exception> predicate = i -> {
-            throw new Exception();
+            throw cause;
         };
         final List<Integer> integers = Collections.singletonList(42);
 
@@ -121,9 +141,6 @@ public class ThrowingPredicateTest {
         integers.stream().anyMatch(i -> predicate.uncheck().test(i));
 
         // then RuntimeException is thrown
+        fail("exception expected");
     }
-
-
-
-
 }

--- a/src/test/java/pl/touk/throwing/ThrowingRunnableTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingRunnableTest.java
@@ -1,21 +1,34 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
 public class ThrowingRunnableTest {
 
-    @Test(expected = IOException.class)
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
     public void shouldRun() throws Exception {
+        thrown.expect(IOException.class);
+        thrown.expectMessage("some message");
+        
         // given
-        ThrowingRunnable<Exception> runnable = () -> { throw new IOException(); };
+        ThrowingRunnable<Exception> runnable = () -> { throw new IOException("some message"); };
 
         // when
         runnable.run();
 
         // then exception thrown
+        fail("exception expected");
     }
 
     @Test
@@ -29,26 +42,40 @@ public class ThrowingRunnableTest {
         // then WrappedException thrown
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldRunUncheckedAndThrow() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        ThrowingRunnable<Exception> runnable = () -> { throw new IOException(); };
+        ThrowingRunnable<Exception> runnable = () -> { throw cause; };
 
         // when
         runnable.unchecked().run();
 
         // then WrappedException thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldRunUncheckedAndThrowUsingUtilsMethod() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        ThrowingRunnable<Exception> runnable = () -> { throw new IOException(); };
+        ThrowingRunnable<Exception> runnable = () -> { throw cause; };
 
         // when
         ThrowingRunnable.unchecked(runnable).run();
 
         // then WrappedException thrown
+        fail("exception expected");
     }
 
 }

--- a/src/test/java/pl/touk/throwing/ThrowingSupplierTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingSupplierTest.java
@@ -1,14 +1,22 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
 
 import java.io.IOException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 
 public class ThrowingSupplierTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldGet() throws Exception {
@@ -70,26 +78,40 @@ public class ThrowingSupplierTest {
         assertThat(result).isEqualTo(42);
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldGetUncheckedAndThrow() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        final ThrowingSupplier<Integer, IOException> supplier = () -> { throw new IOException(); };
+        final ThrowingSupplier<Integer, IOException> supplier = () -> { throw cause; };
 
         // when
         supplier.uncheck().get();
 
         // then exception is thrown
+        fail("exception expected");
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldGetUncheckedWithUtilsFunction() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        final ThrowingSupplier<Integer, IOException> supplier = () -> { throw new IOException(); };
+        final ThrowingSupplier<Integer, IOException> supplier = () -> { throw cause; };
 
         // when
         ThrowingSupplier.unchecked(supplier).get();
 
         // then exception is thrown
+        fail("exception expected");
     }
 
     @Test

--- a/src/test/java/pl/touk/throwing/ThrowingUnaryOperatorTest.java
+++ b/src/test/java/pl/touk/throwing/ThrowingUnaryOperatorTest.java
@@ -1,11 +1,20 @@
 package pl.touk.throwing;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import pl.touk.throwing.exception.WrappedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
 public class ThrowingUnaryOperatorTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void shouldApply() throws Exception {
@@ -29,24 +38,33 @@ public class ThrowingUnaryOperatorTest {
         // then no exception thrown
     }
 
-    @Test(expected = WrappedException.class)
+    @Test
     public void shouldApplyUncheckedAndThrow() throws Exception {
+        final IOException cause = new IOException("some message");
+        
+        thrown.expect(WrappedException.class);
+        thrown.expectMessage("some message");
+        thrown.expectCause(is(cause));
+
         // given
-        ThrowingUnaryOperator<Integer, IOException> op = i -> { throw new IOException(); };
+        ThrowingUnaryOperator<Integer, IOException> op = i -> { throw cause; };
 
         // when
         ThrowingUnaryOperator.unchecked(op).apply(42);
 
         // then an exception is thrown
+        fail("exception expected");
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldApplyUncheckedAndThrowNPE() throws Exception {
+        thrown.expect(NullPointerException.class);
 
         // when
         ThrowingUnaryOperator.unchecked(null).apply(42);
 
         // then NPE is thrown
+        fail("exception expected");
     }
 
 }


### PR DESCRIPTION
As for issue #19, I did the following changes:

* update existing tests to use `ExpectedException` instead of `@Test(expected = SomeException.class)` and 
* fix `ThrowingBinaryOperatorTest` to use `ThrowingBinaryOperator::unchecked` instead of `ThrowingBiFunction::unchecked`

@pivovarit could you take a look?

